### PR TITLE
Issue 1

### DIFF
--- a/WorkLog.md
+++ b/WorkLog.md
@@ -1,3 +1,4 @@
+* query height to avoid repartition error
 * testing repartitioning error
 * altitude repartitioning test
 # 2024-04-16 11:00:42.524247: clock-out

--- a/WorkLog.md
+++ b/WorkLog.md
@@ -1,3 +1,4 @@
+* use existing boto session
 * query height to avoid repartition error
 * testing repartitioning error
 * altitude repartitioning test

--- a/WorkLog.md
+++ b/WorkLog.md
@@ -1,3 +1,4 @@
+* testing repartitioning error
 * altitude repartitioning test
 # 2024-04-16 11:00:42.524247: clock-out
 

--- a/WorkLog.md
+++ b/WorkLog.md
@@ -1,3 +1,4 @@
+* altitude repartitioning test
 # 2024-04-16 11:00:42.524247: clock-out
 
 * debugging file ranges

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-tornado==6.4
+tornado==6.4.1
 jupyter
 jupytext
 notebook==6.4.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    depends_on:
+      - scheduler
+      - worker
+    volumes:
+      - .:/code
     environment:
       SCHEDULER_HOST: tcp://scheduler:8786
       PARQUET_ENDPOINT: ${PARQUET_ENDPOINT}
@@ -36,6 +41,7 @@ services:
       PARQUET_ENGINE: pyarrow
       ACCESS_KEY: ${AWS_ACCESS_KEY_ID}
       SECRET_KEY: ${AWS_SECRET_ACCESS_KEY}
+      MALLOC_CONF: "abort_conf:true" # hides warning <jemalloc>: MADV_DONTNEED does not work
     command:
       - jupyter
       - notebook
@@ -54,7 +60,7 @@ services:
   worker:
     platform: ${PLATFORM}
     image: kamodo/dask
-    command: dask worker tcp://scheduler:8786 --no-nanny --memory-limit 4GB
+    command: dask worker tcp://scheduler:8786
     depends_on:
       - scheduler
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      SCHEDULER_HOST: tcp://scheduler:8786
+      PARQUET_ENDPOINT: ${PARQUET_ENDPOINT}
+      PARQUET_ENGINE: pyarrow
+      ACCESS_KEY: ${AWS_ACCESS_KEY_ID}
+      SECRET_KEY: ${AWS_SECRET_ACCESS_KEY}
     ports:
       - 8000:8000
   dev: # developer notebook to test microservice with db
@@ -39,12 +45,14 @@ services:
       - --ip=0.0.0.0
       - --allow-root
   scheduler:
+    platform: ${PLATFORM}
     image: kamodo/dask
     command: dask scheduler
     ports:
       - 8786:8786 # Scheduler port
       - 8787:8787 # Dashboard port
   worker:
+    platform: ${PLATFORM}
     image: kamodo/dask
     command: dask worker tcp://scheduler:8786 --no-nanny --memory-limit 4GB
     depends_on:
@@ -58,21 +66,25 @@ services:
     deploy:
       replicas: 4
   worker1:
+    platform: ${PLATFORM}
     image: kamodo/dask
     command: dask worker tcp://scheduler:8786 --no-nanny
     depends_on:
       - scheduler
   worker2:
+    platform: ${PLATFORM}
     image: kamodo/dask
     command: dask worker tcp://scheduler:8786 --no-nanny
     depends_on:
       - scheduler
   worker3:
+    platform: ${PLATFORM}
     image: kamodo/dask
     command: dask worker tcp://scheduler:8786 --no-nanny
     depends_on:
       - scheduler
   worker4:
+    platform: ${PLATFORM}
     image: kamodo/dask
     command: dask worker tcp://scheduler:8786 --no-nanny
     depends_on:

--- a/docs/interpolator.md
+++ b/docs/interpolator.md
@@ -13,7 +13,8 @@ client
 ```python
 # from kamodo_dask.kamodo_dask import df_from_dask,
 from kamodo_dask.dask_config import client, storage_options
-from kamodo_dask.kamodo_dask import df_from_dask, KamodoDask, fetch_file_range
+from kamodo_dask.kamodo_dask import df_from_dask, KamodoDask, fetch_file_range, filter_partition
+from kamodo_dask.kamodo_dask import check_file_existence, dd, PARQUET_ENGINE, CancelledError
 
 import os
 
@@ -22,7 +23,7 @@ parquet_endpoint = os.environ.get('PARQUET_ENDPOINT')
 print(parquet_endpoint)
 
 # run this every time you want to fetch new data
-start = pd.Timestamp.utcnow() - pd.Timedelta(days=25.5)
+start = pd.Timestamp.utcnow() - pd.Timedelta(days=2)
 # start = pd.Timestamp(2024, 4, 9, 5, 19)
 
 # fetch up to n hours of data
@@ -36,6 +37,9 @@ h_start, h_end = 292500.0, 357500.0
 ```
 
 ```python
+round_time='10T'
+start = start.floor(round_time)
+end = end.ceil(round_time)
 start, end
 ```
 
@@ -61,26 +65,247 @@ filenames, date_range = fetch_file_range(start, end, parquet_endpoint, '.parquet
 ```
 
 ```python
+filenames
+```
+
+```python
 parquet_endpoint
 ```
 
 ```python
-df = df_from_dask(client, parquet_endpoint, storage_options, start, end, h_start, h_end)
+def df_from_dask(client, endpoint, storage_options, start, end, h_start, h_end, round_time='10T', suffix='.parquet', npartitions=None, partition_size=None, verbose=False):
+    if len(client.ncores()) == 0:
+        raise RuntimeError("No available workers in the Dask cluster. Please ensure that your Dask cluster is properly configured and has active workers.")
+
+    start = start.floor(round_time)
+    end = end.ceil(round_time)
+    h_range = h_start, h_end
+
+    filenames, date_range = fetch_file_range(start, end, endpoint, suffix)
+
+    if not filenames:
+        raise IOError(f"No files found matching query\n start: {start}\n end: {end}")
+
+    if verbose:
+        print('initializing with filenames')
+        print(filenames)
+
+    try:
+        ddf = dd.read_parquet(filenames, engine=PARQUET_ENGINE, storage_options=storage_options)
+
+        if verbose:
+            print(f"Initial number of partitions: {ddf.npartitions}")
+
+        # Repartition if necessary to match the number of workers
+        if npartitions is not None:
+            if verbose:
+                print(f'repartitioning from {ddf.npartitions} to {npartitions}')
+            ddf = ddf.repartition(npartitions=npartitions)
+            if verbose:
+                print(f"Number of partitions after repartitioning: {ddf.npartitions}")
+        elif partition_size is not None:
+            if verbose:
+                print(f'repartitioning from {ddf.npartitions} to {partition_size} MB per partition')
+            ddf = ddf.repartition(partition_size=partition_size)
+            if verbose:
+                print(f"Number of partitions after repartitioning: {ddf.npartitions}")
+
+        meta = ddf._meta
+        ddf = ddf.map_partitions(filter_partition, h_range=h_range, meta=meta)
+
+        if verbose:
+            print(f"Number of partitions after map_partitions: {ddf.npartitions}")
+
+        # Ensure no implicit repartitioning is happening
+        if verbose:
+            print("Persisting DataFrame")
+        ddf = client.persist(ddf, retries=3)
+
+        if verbose:
+            print(f"Number of partitions after persist: {ddf.npartitions}")
+
+        max_attempts = 3
+        attempts = 0
+        while attempts < max_attempts:
+            try:
+                df = ddf.compute(timeout=1200)  # Adjust timeout as needed
+                break  # If compute is successful, break out of the loop
+            except (TimeoutError, CancelledError) as e:
+                attempts += 1
+                print(e)
+                print(f"Attempt {attempts}. Retrying...")
+                if attempts < max_attempts:
+                    # Clean up memory and rebalance data
+                    client.cancel(ddf)
+                    client.rebalance()
+                    ddf = client.persist(ddf, retries=3)  # Persist the DataFrame again
+                else:
+                    if ddf is not None:
+                        client.cancel(ddf)  # Cancel all associated tasks and free up resources only if ddf is defined
+                    raise Exception("Max retries reached. Failing now.")
+
+        # Post-processing steps
+        repetitions = len(df) // len(date_range)
+        times = np.repeat(date_range, repetitions)
+        lat_values = df.index.get_level_values('lat')
+        lon_values = df.index.get_level_values('lon')
+        h_values = df.index.get_level_values('h')
+
+        new_tuples = list(zip(times, lon_values, lat_values, h_values))
+        new_index = pd.MultiIndex.from_tuples(new_tuples, names=["time", "lon", "lat", "h"])
+        df = df.set_index(new_index)
+
+        return df
+    except FileNotFoundError as m:
+        print('files not found')
+        print(filenames)
+        raise
+    except Exception as e:
+        if 'ddf' in locals():
+            client.cancel(ddf)  # Ensure cleanup on any exception, only if ddf is defined
+        print(f"Error processing data: {e}")
+        raise
 ```
 
 ```python
-df.shape
+filenames, date_range = fetch_file_range(start, end, parquet_endpoint, '.parquet')
 ```
 
 ```python
-df.head()
+filenames
+```
+
+```python
+date_range
+```
+
+## Trying new height partitioning
+
+```python
+def filter_partition(df, h_range):
+    # Convert the 'h' level of the index to a separate column for filtering
+    df['h_temp'] = pd.to_numeric(df.index.get_level_values('h'), errors='coerce')
+    
+    # Determine the bounds for filtering
+    h_min, h_max = h_range
+    
+    # Ensure filtering within the specified bounds
+    filtered_df = df[df['h_temp'].between(h_min, h_max, inclusive='both')]
+    
+    # Drop the temporary column
+    filtered_df = filtered_df.drop(columns=['h_temp'])
+
+    return filtered_df
+```
+
+```python
+def parquet_to_ddf(filenames, storage_options=None, engine='pyarrow', verbose=False):
+    """
+    Constructs a Dask DataFrame from a list of Parquet files.
+
+    Parameters:
+    - filenames: List of Parquet file paths.
+    - storage_options: Dictionary of storage options to pass to the backend file system (e.g., S3 options).
+    - engine: Parquet engine to use ('pyarrow' or 'fastparquet').
+    - verbose: If True, print additional information.
+
+    Returns:
+    - ddf: Dask DataFrame.
+    """
+    if verbose:
+        print("Initializing Dask DataFrame with filenames:")
+        for _ in filenames:
+            print(_)
+    
+    print(dd)
+    # Create Dask DataFrame from the list of Parquet files
+    ddf = dd.read_parquet(filenames, engine=engine, storage_options=storage_options)
+    
+    if verbose:
+        print(f"Number of partitions: {ddf.npartitions}")
+    
+    return ddf
+
+ddf = parquet_to_ddf(filenames, storage_options=storage_options, engine='pyarrow', verbose=True)
+```
+
+```python
+ddf
+```
+
+```python
+ddf.head()
+```
+
+```python
+h_range = h_start, h_end
+```
+
+```python
+meta = ddf._meta
+ddf_filtered = ddf.map_partitions(filter_partition, h_range=h_range, meta=meta)
+```
+
+```python
+# Persist the filtered DataFrame
+ddf_filtered = client.persist(ddf_filtered)
+```
+
+```python
+h_range
+```
+
+```python
+# Compute the result to get a Pandas DataFrame
+result = ddf_filtered.compute()
+
+# Print the resulting Pandas DataFrame
+print(result)
+```
+
+```python
+df = result
+```
+
+```python
+len(df)//len(date_range)
+```
+
+```python
+import numpy as np
+```
+
+```python
+# Post-processing steps
+repetitions = len(df) // len(date_range)
+times = np.repeat(date_range, repetitions)
+lat_values = df.index.get_level_values('lat')
+lon_values = df.index.get_level_values('lon')
+h_values = df.index.get_level_values('h')
+
+new_tuples = list(zip(times, lon_values, lat_values, h_values))
+new_index = pd.MultiIndex.from_tuples(new_tuples, names=["time", "lon", "lat", "h"])
+df = df.set_index(new_index)
 ```
 
 ```python
 df
 ```
 
+```python
+# df = df_from_dask(client, parquet_endpoint, storage_options,
+#                   start, end, h_start, h_end, partition_size='200MB', verbose=True)
+```
+
+```python
+df.head()
+```
+
 Construct a Kamodo object using the retrieved data
+
+```python
+df.index.levels
+```
 
 ```python
 kd = KamodoDask(df)
@@ -130,7 +355,27 @@ kd.plot('rho_ijkl', plot_partial=dict(rho_ijkl=dict(lon=200, lat=0,  h=midpoint[
 ## plot slice
 
 ```python
-kd.plot('rho_ijkl', plot_partial=dict(rho_ijkl=dict(lon=200, lat=0)))
+midpoint['lon']
+```
+
+```python
+midpoint
+```
+
+```python
+kd.df
+```
+
+```python
+kd.rho_ijkl(time=midpoint['time'], lon=midpoint['lon']).shape
+```
+
+```python
+## this will not render if there's only 3 values in altitude
+```
+
+```python
+kd.plot('rho_ijkl', plot_partial=dict(rho_ijkl=dict(time=midpoint['time'], lon=midpoint['lon'])))
 ```
 
 ```python

--- a/kamodo_dask/dask_config.py
+++ b/kamodo_dask/dask_config.py
@@ -52,21 +52,20 @@ boto_config = Config(
     }
 )
 
-# Create a boto3 client using the custom configuration
-s3_client = boto3.client(
-    's3',
-    aws_access_key_id=os.environ['ACCESS_KEY'],
-    aws_secret_access_key=os.environ['SECRET_KEY'],
-    config=boto_config
-)
-
-
-
 # Create a boto3 session with AWS credentials
 boto_session = boto3.Session(
     aws_access_key_id=os.environ['ACCESS_KEY'],
     aws_secret_access_key=os.environ['SECRET_KEY'],
 )
+
+def get_s3_client():
+    """use session to create client to keep connection open"""
+    s3_client = boto_session.client('s3', config=boto_config)
+
+    return s3_client
+
+s3_client = get_s3_client()
+
 
 # Configuring the S3FileSystem with the custom connection pool size
 fs = s3fs.S3FileSystem(

--- a/kamodo_dask/dask_config.py
+++ b/kamodo_dask/dask_config.py
@@ -45,7 +45,7 @@ import s3fs
 
 # Define the custom configuration for the boto3 client
 boto_config = Config(
-    max_pool_connections=50,  # Custom connection pool size
+    max_pool_connections=max_pool_connections,  # Custom connection pool size
     retries = {
         'max_attempts': 10,
         'mode': 'standard'
@@ -81,7 +81,7 @@ fs = s3fs.S3FileSystem(
 storage_options = {
     'key': os.environ['ACCESS_KEY'],
     'secret': os.environ['SECRET_KEY'],
-    'client_kwargs': {
-        'config': Config(max_pool_connections=50)  # Custom connection pool size
+    'config_kwargs': {
+        'max_pool_connections': max_pool_connections  # Custom connection pool size
     }
 }

--- a/kamodo_dask/kamodo_dask.py
+++ b/kamodo_dask/kamodo_dask.py
@@ -93,29 +93,6 @@ def get_parquet_buffer(df):
     buffer.seek(0)
     return buffer
 
-def filter_partition(df, h_range):
-    # Convert the 'h' level of the index to a separate column for filtering
-    df['h_temp'] = pd.to_numeric(df.index.get_level_values('h'), errors='coerce')
-    
-    # Determine the bounds for filtering
-    h_min, h_max = h_range
-    h_lower = df['h_temp'][(df['h_temp'] < h_min)].max()
-    h_upper = df['h_temp'][(df['h_temp'] > h_max)].min()
-
-    # Adjust h_lower or h_upper if they are NaN
-    if pd.isna(h_lower):
-        h_lower = df['h_temp'].min()
-    if pd.isna(h_upper):
-        h_upper = df['h_temp'].max()
-
-    # Ensure filtering within the adjusted bounds
-    filtered_df = df[df['h_temp'].between(h_lower, h_upper, inclusive='both')]
-
-    # Drop the temporary column
-    filtered_df = filtered_df.drop(columns=['h_temp'])
-
-    return filtered_df
-
 
 def extract_timestamp_from_filename(filename, prefix, postfix):
     # Extract the timestamp from the filename
@@ -128,7 +105,81 @@ def add_timestamp_to_partition(df, timestamp):
     return df
 
 
+def parquet_to_ddf(filenames, storage_options=None, engine='pyarrow', verbose=False):
+    """
+    Constructs a Dask DataFrame from a list of Parquet files.
+
+    Parameters:
+    - filenames: List of Parquet file paths.
+    - storage_options: Dictionary of storage options to pass to the backend file system (e.g., S3 options).
+    - engine: Parquet engine to use ('pyarrow' or 'fastparquet').
+    - verbose: If True, print additional information.
+
+    Returns:
+    - ddf: Dask DataFrame.
+    """
+    if verbose:
+        print("Initializing Dask DataFrame with filenames:")
+        for _ in filenames:
+            print(_)
+
+    # Create Dask DataFrame from the list of Parquet files
+    ddf = dd.read_parquet(filenames, engine=engine, storage_options=storage_options)
+
+    if verbose:
+        print(f"Number of partitions: {ddf.npartitions}")
+
+    return ddf
+
+def filter_partition(df, h_range):
+    # Convert the 'h' level of the index to a separate column for filtering
+    df['h_temp'] = pd.to_numeric(df.index.get_level_values('h'), errors='coerce')
+
+    # Determine the bounds for filtering
+    h_min, h_max = h_range
+
+    # Ensure filtering within the specified bounds
+    filtered_df = df[df['h_temp'].between(h_min, h_max, inclusive='both')]
+
+    # Drop the temporary column
+    filtered_df = filtered_df.drop(columns=['h_temp'])
+
+    return filtered_df
+
+def df_from_parquet(client, parquet_endpoint, storage_options, engine, start, end, h_start, h_end, filter_function=None):
+    filenames, date_range = fetch_file_range(start, end, parquet_endpoint, '.parquet')
+
+    ddf = parquet_to_ddf(filenames, storage_options=storage_options, engine=engine)
+
+    h_range = h_start, h_end
+
+    meta = ddf._meta
+
+    if filter_function is not None:
+        ddf_filtered = ddf.map_partitions(filter_function, h_range=h_range, meta=meta)
+
+    # Persist the filtered DataFrame
+    ddf_filtered = client.persist(ddf_filtered)
+
+    # Compute the result to get a Pandas DataFrame
+    df = ddf_filtered.compute()
+
+    # Post-processing steps
+    repetitions = len(df) // len(date_range)
+    times = np.repeat(date_range, repetitions)
+    lat_values = df.index.get_level_values('lat')
+    lon_values = df.index.get_level_values('lon')
+    h_values = df.index.get_level_values('h')
+
+    new_tuples = list(zip(times, lon_values, lat_values, h_values))
+    new_index = pd.MultiIndex.from_tuples(new_tuples, names=["time", "lon", "lat", "h"])
+    df = df.set_index(new_index)
+
+    return df
+
 def df_from_dask(client, endpoint, storage_options, start, end, h_start, h_end, round_time='10T', suffix='.parquet', npartitions=None, partition_size=None, verbose=False):
+    """this code is defunct, please use kamodo_dask.df_from_parquet"""
+
     if len(client.ncores()) == 0:
         raise RuntimeError("No available workers in the Dask cluster. Please ensure that your Dask cluster is properly configured and has active workers.")
 
@@ -166,7 +217,7 @@ def df_from_dask(client, endpoint, storage_options, start, end, h_start, h_end, 
                 print(f"Number of partitions after repartitioning: {ddf.npartitions}")
 
         meta = ddf._meta
-        ddf = ddf.map_partitions(filter_partition, h_range=h_range, meta=meta)
+        ddf = ddf.map_partitions(filter_altitude, h_range=h_range, meta=meta)
 
         if verbose:
             print(f"Number of partitions after map_partitions: {ddf.npartitions}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ pyarrow
 fastparquet
 boto3==1.26.90
 s3fs>=2023.4.0
+dask==2024.4.2
+distributed==2024.4.2
 dask[dataframe]
-distributed
+pandas==2.2.2
 bokeh!=3.0.*,>=2.4.2

--- a/test/test_parquet_load.py
+++ b/test/test_parquet_load.py
@@ -1,0 +1,121 @@
+"""
+loads 2 hrs of parquet files from memory using fixed altitude range
+
+run from kamodo/daskdev
+
+This version defines the filter_partition function on the client
+(seems to work better when the worker/schduler are different images from the client)
+"""
+
+import os
+import pandas as pd
+from dask.distributed import Client
+import dask.dataframe as dd
+from kamodo_dask.dask_config import client, storage_options
+from kamodo_dask.kamodo_dask import df_from_parquet, fetch_file_range
+import numpy as np
+
+# Define the filter_partition function within the script
+def filter_partition(df, h_range):
+    # Convert the 'h' level of the index to a separate column for filtering
+    df['h_temp'] = pd.to_numeric(df.index.get_level_values('h'), errors='coerce')
+    
+    # Determine the bounds for filtering
+    h_min, h_max = h_range
+    
+    # Ensure filtering within the specified bounds
+    filtered_df = df[df['h_temp'].between(h_min, h_max, inclusive='both')]
+    
+    # Drop the temporary column
+    filtered_df = filtered_df.drop(columns=['h_temp'])
+
+    return filtered_df
+
+def parquet_to_ddf(filenames, storage_options=None, engine='pyarrow', verbose=False):
+    """
+    Constructs a Dask DataFrame from a list of Parquet files.
+
+    Parameters:
+    - filenames: List of Parquet file paths.
+    - storage_options: Dictionary of storage options to pass to the backend file system (e.g., S3 options).
+    - engine: Parquet engine to use ('pyarrow' or 'fastparquet').
+    - verbose: If True, print additional information.
+
+    Returns:
+    - ddf: Dask DataFrame.
+    """
+    if verbose:
+        print("Initializing Dask DataFrame with filenames:")
+        for filename in filenames:
+            print(filename)
+
+    # Create Dask DataFrame from the list of Parquet files
+    ddf = dd.read_parquet(filenames, engine=engine, storage_options=storage_options)
+
+    if verbose:
+        print(f"Number of partitions: {ddf.npartitions}")
+
+    return ddf
+
+def df_from_parquet(client, parquet_endpoint, storage_options, engine, start, end, h_start, h_end):
+    filenames, date_range = fetch_file_range(start, end, parquet_endpoint, '.parquet')
+
+    ddf = parquet_to_ddf(filenames, storage_options=storage_options, engine=engine)
+
+    h_range = h_start, h_end
+
+    meta = ddf._meta
+    ddf_filtered = ddf.map_partitions(filter_partition, h_range=h_range, meta=meta)
+
+    # Persist the filtered DataFrame
+    ddf_filtered = client.persist(ddf_filtered)
+
+    # Compute the result to get a Pandas DataFrame
+    df = ddf_filtered.compute()
+
+    # Post-processing steps
+    repetitions = len(df) // len(date_range)
+    times = np.repeat(date_range, repetitions)
+    lat_values = df.index.get_level_values('lat')
+    lon_values = df.index.get_level_values('lon')
+    h_values = df.index.get_level_values('h')
+
+    new_tuples = list(zip(times, lon_values, lat_values, h_values))
+    new_index = pd.MultiIndex.from_tuples(new_tuples, names=["time", "lon", "lat", "h"])
+    df = df.set_index(new_index)
+
+    return df
+
+def main():
+    # Fetch the parquet endpoint from environment variables
+    parquet_endpoint = os.environ.get('PARQUET_ENDPOINT')
+
+    # Print the parquet endpoint to verify it was fetched correctly
+    print(f"Parquet Endpoint: {parquet_endpoint}")
+
+    # Set the start time to 2 days ago from the current UTC time
+    start = pd.Timestamp.utcnow() - pd.Timedelta(days=2)
+
+    # Fetch up to 2 hours of data
+    hours_of_data = 2
+    end = start + pd.Timedelta(seconds=hours_of_data * 60 * 60)
+
+    # Set the range of altitude to fetch
+    h_start, h_end = 292500.0, 357500.0
+
+    # Round the start and end times
+    round_time = '10T'
+    start = start.floor(round_time)
+    end = end.ceil(round_time)
+
+    print(f"Start Time: {start}, End Time: {end}")
+
+    # Fetch the 4D dataframe using the parquet endpoint
+    df = df_from_parquet(client, parquet_endpoint, storage_options, 'pyarrow', start, end, h_start, h_end)
+
+    # Print the resulting dataframe
+    print(df)
+
+if __name__ == "__main__":
+    main()
+

--- a/test/test_parquet_prod.py
+++ b/test/test_parquet_prod.py
@@ -1,0 +1,59 @@
+"""
+loads 2 hrs of parquet files from memory using fixed altitude range
+
+this version attemps to load the files without defining filter_partitions in the client
+"""
+
+import os
+import dask
+import pandas as pd
+from kamodo_dask.dask_config import client, storage_options
+from kamodo_dask.kamodo_dask import df_from_parquet, fetch_file_range, filter_partition
+
+
+import cloudpickle
+
+from kamodo_dask.kamodo_dask import filter_partition
+
+try:
+    serialized_func = cloudpickle.dumps(filter_partition)
+    print("Function serialized successfully.")
+except Exception as e:
+    print(f"Serialization error: {e}")
+
+
+dask.config.set({"distributed.worker.serialization": cloudpickle})
+
+def main():
+    # Fetch the parquet endpoint from environment variables
+    parquet_endpoint = os.environ.get('PARQUET_ENDPOINT')
+
+    # Print the parquet endpoint to verify it was fetched correctly
+    print(f"Parquet Endpoint: {parquet_endpoint}")
+
+    # Set the start time to 2 days ago from the current UTC time
+    start = pd.Timestamp.utcnow() - pd.Timedelta(days=2)
+
+    # Fetch up to 2 hours of data
+    hours_of_data = 2
+    end = start + pd.Timedelta(seconds=hours_of_data * 60 * 60)
+
+    # Set the range of altitude to fetch
+    h_start, h_end = 292500.0, 357500.0
+
+    # Round the start and end times
+    round_time = '10T'
+    start = start.floor(round_time)
+    end = end.ceil(round_time)
+
+    print(f"Start Time: {start}, End Time: {end}")
+
+    # Fetch the 4D dataframe using the parquet endpoint
+    df = df_from_parquet(client, parquet_endpoint, storage_options, 'pyarrow', start, end, h_start, h_end,
+            filter_function=filter_partition)
+
+    # Print the resulting dataframe
+    print(df)
+
+if __name__ == "__main__":
+    main()

--- a/test/test_parquet_prod.py
+++ b/test/test_parquet_prod.py
@@ -8,21 +8,8 @@ import os
 import dask
 import pandas as pd
 from kamodo_dask.dask_config import client, storage_options
-from kamodo_dask.kamodo_dask import df_from_parquet, fetch_file_range, filter_partition
+from kamodo_dask.kamodo_dask import df_from_parquet, fetch_file_range
 
-
-import cloudpickle
-
-from kamodo_dask.kamodo_dask import filter_partition
-
-try:
-    serialized_func = cloudpickle.dumps(filter_partition)
-    print("Function serialized successfully.")
-except Exception as e:
-    print(f"Serialization error: {e}")
-
-
-dask.config.set({"distributed.worker.serialization": cloudpickle})
 
 def main():
     # Fetch the parquet endpoint from environment variables
@@ -49,8 +36,8 @@ def main():
     print(f"Start Time: {start}, End Time: {end}")
 
     # Fetch the 4D dataframe using the parquet endpoint
-    df = df_from_parquet(client, parquet_endpoint, storage_options, 'pyarrow', start, end, h_start, h_end,
-            filter_function=filter_partition)
+    df = df_from_parquet(client, parquet_endpoint, storage_options, 'pyarrow',
+        start, end, h_start, h_end)
 
     # Print the resulting dataframe
     print(df)


### PR DESCRIPTION
Addresses #1 

test altitude range filter

to test:

```sh
docker compose build kamodo-dask
docker compose run kamodo-dask bash
root@f2dbf20e6e7b:/code# python test/test_parquet_load.py ## succeeds
```

The above works when the `filter_partition` function is defined within the `test_parquet_load.py` script.

However, if we import `filter_partition` then the script will fail - this is done in `test_parquet_prod.py`

```sh
(base) root@f2dbf20e6e7b:/code/test# python test_parquet_prod.py 
<jemalloc>: MADV_DONTNEED does not work (memset will be used instead)
<jemalloc>: (This is the expected behaviour if you are running under QEMU)
kamodo-dask connecting to scheduler_host: tcp://scheduler:8786
Function serialized successfully.
Parquet Endpoint: s3://ctipe-data/updated-neuraspace-rho-fix/CTIPE_RHO_GEO_
Start Time: 2024-07-31 15:40:00+00:00, End Time: 2024-07-31 17:50:00+00:00
Traceback (most recent call last):
  File "/code/test/test_parquet_prod.py", line 59, in <module>
    main()
  File "/code/test/test_parquet_prod.py", line 52, in main
    df = df_from_parquet(client, parquet_endpoint, storage_options, 'pyarrow', start, end, h_start, h_end,
  File "/code/kamodo_dask/kamodo_dask.py", line 165, in df_from_parquet
    df = ddf_filtered.compute()
  File "/opt/conda/lib/python3.10/site-packages/dask_expr/_collection.py", line 475, in compute
    return DaskMethodsMixin.compute(out, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/dask/base.py", line 375, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/dask/base.py", line 661, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/distributed/client.py", line 2233, in _gather
    raise exc
concurrent.futures._base.CancelledError: ('repartitiontofewer-30865e0d5246ac758e7753f7fd204948', 0)
```