### PR TITLE
Issue 1

### DIFF
--- a/WorkLog.md
+++ b/WorkLog.md
@@ -1,3 +1,4 @@
+* fix range query
 * use existing boto session
 * query height to avoid repartition error
 * testing repartitioning error


### PR DESCRIPTION
There was a bug in range query that was breaking the flythrough.
This fix makes the range query use bounds that come from the closest available heights in the parquet files. 